### PR TITLE
"see github" boton arreglado

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,7 +30,7 @@ export default function Component() {
                                 </div>
                                 <div className="flex flex-col gap-2 min-[400px]:flex-row">
                                     <Button asChild>
-                                        <Link href="/login"> See Github</Link>
+                                        <a href="https://github.com/ksreyr/web-site-discord-comunity" target="_blank"> See Github</a>
                                     </Button>
                                 </div>
                             </div>


### PR DESCRIPTION
se arreglo el error de direccionamiento del boton "See github", que llevaba a una pagina interna no existente en lugar de al repositorio de github.

se tuvo que remplazar el componente "Link" por el elemento "a" ya que este ultimo permite la navegacion a otras paginas mientras que "Link" solo se usa como metodo de navegacion entre las rutas de una misma aplicacion

se agrego el atributo target="_blank" para que el repositorio sea abierto en una nueva pestaña y no se cierre la pagina de la comunidad dañando ligeramente la UX 